### PR TITLE
Replace all S3 image URLs with client-side generation

### DIFF
--- a/src/lib/components/CompositionBuilder.svelte
+++ b/src/lib/components/CompositionBuilder.svelte
@@ -3,6 +3,7 @@ import type { UnsigMetadata, OwnedUnsig } from '$lib/types';
 import { BrowserWalletState } from '@meshsdk/svelte';
 import Modal from '$lib/components/Modal.svelte';
 import CompositionGrid from '$lib/components/CompositionGrid.svelte';
+import UnsigImage from '$lib/components/UnsigImage.svelte';
 
 const UNSIGS_POLICY_ID = '0e14267a8020229adc0184dd25fa3174c3f7d6caadcb4425c70e7c04';
 
@@ -352,8 +353,9 @@ function createMetadata() {
                                 ondragstart={() => startDrag(unsig.id, unsig.hexAssetName)}
                                 role="button"
                                 tabindex="0">
-                                <img
-                                    src="https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/128/{unsig.id.toString().padStart(5, '0')}.png"
+                                <UnsigImage
+                                    id={unsig.id}
+                                    dim={128}
                                     alt="unsig {unsig.id}"
                                     class="w-full h-full object-cover"
                                 />

--- a/src/lib/components/CompositionGrid.svelte
+++ b/src/lib/components/CompositionGrid.svelte
@@ -2,6 +2,8 @@
   import { browser } from '$app/environment';
   import { unsigs } from '$lib/unsigs';
   import { createWorkerPool } from '$lib/unsig/worker-pool';
+  import { getCachedUrl } from '$lib/unsig/image-cache';
+  import UnsigImage from '$lib/components/UnsigImage.svelte';
   import type { UnsigData } from '$lib/types';
 
   type GridPosition = {
@@ -296,11 +298,15 @@
             {#if cell.unsigId !== null}
               {@const cachedUrl = imageCache.get(cell.unsigId)}
               <div class="cell-image">
-                <img
-                  src={cachedUrl || `https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/128/${cell.unsigId.toString().padStart(5, '0')}.png`}
-                  alt="unsig {cell.unsigId}"
-                  draggable="false"
-                />
+                {#if cachedUrl}
+                  <img
+                    src={cachedUrl}
+                    alt="unsig {cell.unsigId}"
+                    draggable="false"
+                  />
+                {:else}
+                  <UnsigImage id={cell.unsigId} dim={128} alt="unsig {cell.unsigId}" />
+                {/if}
               </div>
             {:else}
               <div class="cell-empty"></div>

--- a/src/lib/components/PairsDisplay.svelte
+++ b/src/lib/components/PairsDisplay.svelte
@@ -5,6 +5,7 @@
 		type EdgeIndex,
 		type Arrangement,
 	} from '$lib/unsig/edges';
+	import UnsigImage from '$lib/components/UnsigImage.svelte';
 
 	interface Props {
 		ownedIds: number[];
@@ -28,10 +29,6 @@
 	});
 
 	let ownedSet = $derived(new Set(ownedIds));
-
-	function imgUrl(id: number): string {
-		return `https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/256/${id.toString().padStart(5, '0')}.png`;
-	}
 
 	function formatId(id: number): string {
 		return `#${id.toString().padStart(5, '0')}`;
@@ -79,11 +76,11 @@
 								class="grid-cell"
 								class:owned={ownedSet.has(id)}
 							>
-								<img
-									src={imgUrl(id)}
+								<UnsigImage
+									{id}
+									dim={256}
 									alt={formatId(id)}
 									class="cell-img"
-									loading="lazy"
 								/>
 								<div class="cell-info">
 									<span class="cell-id">{formatId(id)}</span>

--- a/src/lib/components/UnsigImage.svelte
+++ b/src/lib/components/UnsigImage.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { generateImage, getCachedUrl } from '$lib/unsig/image-cache';
+
+	interface Props {
+		id: number;
+		dim?: number;
+		alt?: string;
+		class?: string;
+	}
+
+	let { id, dim = 128, alt = '', class: className = '' }: Props = $props();
+
+	let url = $state<string | null>(null);
+
+	$effect(() => {
+		if (!browser) return;
+
+		// Check cache synchronously for instant render
+		const cached = getCachedUrl(id, dim);
+		if (cached) {
+			url = cached;
+			return;
+		}
+
+		// Reset while generating
+		url = null;
+
+		generateImage(id, dim).then((dataUrl) => {
+			url = dataUrl;
+		});
+	});
+</script>
+
+{#if url}
+	<img src={url} alt={alt || `unsig #${id.toString().padStart(5, '0')}`} class={className} />
+{:else}
+	<div class="placeholder {className}" aria-label={alt || `unsig #${id.toString().padStart(5, '0')}`}></div>
+{/if}
+
+<style>
+	.placeholder {
+		background: black;
+		aspect-ratio: 1;
+	}
+
+	img {
+		aspect-ratio: 1;
+	}
+</style>

--- a/src/lib/components/UnsigSelector.svelte
+++ b/src/lib/components/UnsigSelector.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-let { 
-    unsigIndices = [], 
-    onSelect, 
+import UnsigImage from '$lib/components/UnsigImage.svelte';
+
+let {
+    unsigIndices = [],
+    onSelect,
     onClose,
     selectedUnsigId = null
 } = $props<{
@@ -29,8 +31,9 @@ function toggleDropdown() {
         class="w-full h-full aspect-square bg-gray-50 border border-gray-200 hover:border-black transition-colors relative"
         onclick={toggleDropdown}>
         {#if selectedUnsigId !== null}
-            <img 
-                src="https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/128/{selectedUnsigId.toString().padStart(5, '0')}.png"
+            <UnsigImage
+                id={selectedUnsigId}
+                dim={128}
                 alt="unsig {selectedUnsigId}"
                 class="w-full h-full object-cover"
             />
@@ -51,8 +54,9 @@ function toggleDropdown() {
                     <button
                         class="aspect-square border hover:border-black transition-colors p-1 bg-white relative group"
                         onclick={() => handleSelect(unsigId)}>
-                        <img
-                            src="https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/128/{unsigId.toString().padStart(5, '0')}.png"
+                        <UnsigImage
+                            id={unsigId}
+                            dim={128}
                             alt="unsig {unsigId}"
                             class="w-full h-full object-cover"
                         />

--- a/src/lib/unsig/image-cache.ts
+++ b/src/lib/unsig/image-cache.ts
@@ -1,0 +1,217 @@
+// Shared singleton worker pool + LRU cache for unsig image generation.
+// All components use this instead of S3 URLs. SSR-safe (no-ops on server).
+
+import type { UnsigData } from '$lib/types';
+import { unsigs } from '$lib/unsigs';
+
+const MAX_CACHE_SIZE = 2000;
+
+// ── LRU cache (Map preserves insertion order) ────────────────────────
+
+const cache = new Map<string, string>();
+
+function cacheKey(id: number, dim: number): string {
+	return `${id}:${dim}`;
+}
+
+function cacheGet(id: number, dim: number): string | null {
+	const key = cacheKey(id, dim);
+	const url = cache.get(key);
+	if (!url) return null;
+	// Move to end (most recently used)
+	cache.delete(key);
+	cache.set(key, url);
+	return url;
+}
+
+function cacheSet(id: number, dim: number, url: string): void {
+	const key = cacheKey(id, dim);
+	cache.delete(key);
+	cache.set(key, url);
+	if (cache.size > MAX_CACHE_SIZE) {
+		const oldest = cache.keys().next().value;
+		if (oldest !== undefined) cache.delete(oldest);
+	}
+}
+
+// ── In-flight deduplication ──────────────────────────────────────────
+
+const inFlight = new Map<string, Promise<string>>();
+
+// ── Singleton worker pool ────────────────────────────────────────────
+
+interface WorkerEntry {
+	worker: Worker;
+	busy: boolean;
+}
+
+interface QueuedJob {
+	unsigData: UnsigData;
+	dim: number;
+	jobId: number;
+}
+
+interface PoolHandle {
+	generate(id: number, dim: number): Promise<string>;
+}
+
+let pool: PoolHandle | null = null;
+
+function createPool(): PoolHandle {
+	const workerCount = Math.min(navigator.hardwareConcurrency || 4, 4);
+	const workers: WorkerEntry[] = [];
+	const queue: QueuedJob[] = [];
+	const callbacks = new Map<
+		number,
+		{ resolve: (url: string) => void; reject: (err: Error) => void; dim: number; index: number }
+	>();
+	let nextId = 0;
+
+	// Reusable canvas for RGBA → data URL
+	let cvs: HTMLCanvasElement | null = null;
+	let ctx: CanvasRenderingContext2D | null = null;
+
+	function rgbaToDataUrl(buffer: ArrayBuffer, dim: number): string {
+		if (!cvs) {
+			cvs = document.createElement('canvas');
+			ctx = cvs.getContext('2d')!;
+		}
+		if (cvs.width !== dim || cvs.height !== dim) {
+			cvs.width = dim;
+			cvs.height = dim;
+		}
+		const imageData = new ImageData(new Uint8ClampedArray(buffer), dim, dim);
+		ctx!.putImageData(imageData, 0, 0);
+		return cvs.toDataURL();
+	}
+
+	function processQueue() {
+		while (queue.length > 0) {
+			const idle = workers.find((w) => !w.busy);
+			if (!idle) break;
+			const job = queue.shift()!;
+			idle.busy = true;
+			idle.worker.postMessage({
+				type: 'generate',
+				jobId: job.jobId,
+				unsig: {
+					index: job.unsigData.index,
+					num_props: job.unsigData.num_props,
+					properties: job.unsigData.properties,
+				},
+				dim: job.dim,
+			});
+		}
+	}
+
+	for (let i = 0; i < workerCount; i++) {
+		const worker = new Worker(
+			new URL('./unsig.worker.ts', import.meta.url),
+			{ type: 'module' },
+		);
+		const entry: WorkerEntry = { worker, busy: false };
+
+		worker.onmessage = (e) => {
+			const msg = e.data;
+			if (msg.type === 'complete') {
+				entry.busy = false;
+				const cb = callbacks.get(msg.jobId);
+				if (cb) {
+					const url = rgbaToDataUrl(msg.imageData, cb.dim);
+					cacheSet(cb.index, cb.dim, url);
+					cb.resolve(url);
+					callbacks.delete(msg.jobId);
+				}
+				processQueue();
+			} else if (msg.type === 'error') {
+				entry.busy = false;
+				const cb = callbacks.get(msg.jobId);
+				if (cb) {
+					cb.reject(new Error(msg.error));
+					callbacks.delete(msg.jobId);
+				}
+				processQueue();
+			}
+		};
+
+		worker.onerror = (e) => {
+			console.error('[image-cache] worker error:', e.message);
+		};
+
+		workers.push(entry);
+	}
+
+	function generate(id: number, dim: number): Promise<string> {
+		const unsigData = unsigs[id.toString()];
+		if (!unsigData) {
+			return Promise.reject(new Error(`Unknown unsig ${id}`));
+		}
+
+		return new Promise((resolve, reject) => {
+			const jobId = nextId++;
+			callbacks.set(jobId, { resolve, reject, dim, index: id });
+			queue.push({ unsigData, dim, jobId });
+			processQueue();
+		});
+	}
+
+	return { generate };
+}
+
+function getPool(): PoolHandle {
+	if (!pool) pool = createPool();
+	return pool;
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Get a cached data URL for an unsig, or null if not yet generated.
+ */
+export function getCachedUrl(id: number, dim: number): string | null {
+	return cacheGet(id, dim);
+}
+
+/**
+ * Generate (or return cached) data URL for a single unsig.
+ * Deduplicates concurrent requests for the same id+dim.
+ */
+export function generateImage(id: number, dim: number): Promise<string> {
+	if (typeof window === 'undefined') {
+		return Promise.reject(new Error('generateImage requires a browser environment'));
+	}
+
+	const cached = cacheGet(id, dim);
+	if (cached) return Promise.resolve(cached);
+
+	const key = cacheKey(id, dim);
+	const existing = inFlight.get(key);
+	if (existing) return existing;
+
+	const promise = getPool()
+		.generate(id, dim)
+		.finally(() => inFlight.delete(key));
+	inFlight.set(key, promise);
+	return promise;
+}
+
+/**
+ * Generate images for a list of unsig IDs. Calls onResult for each
+ * as they complete (cached ones fire immediately).
+ */
+export function generateBatch(
+	ids: number[],
+	dim: number,
+	onResult: (id: number, url: string) => void,
+): void {
+	if (typeof window === 'undefined') return;
+
+	for (const id of ids) {
+		const cached = cacheGet(id, dim);
+		if (cached) {
+			onResult(id, cached);
+		} else {
+			generateImage(id, dim).then((url) => onResult(id, url));
+		}
+	}
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import { browser } from '$app/environment';
   import { unsigs } from '$lib/unsigs';
   import { renderProgressively } from '$lib/unsig/render';
+  import UnsigImage from '$lib/components/UnsigImage.svelte';
 
   const TOTAL_UNSIGS = 31119;
   const HOLD_DURATION = 6000;
@@ -177,22 +178,20 @@
     }
   }
 
-  // Sample grid images
-  function getSampleGridUrls(): string[] {
+  // Sample grid IDs
+  function getSampleGridIds(): number[] {
     const indices: number[] = [];
     while (indices.length < 16) {
       const id = Math.floor(Math.random() * TOTAL_UNSIGS);
       if (!indices.includes(id) && id > 0) indices.push(id);
     }
-    return indices.map(id =>
-      `https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/128/${id.toString().padStart(5, '0')}.png`
-    );
+    return indices;
   }
 
-  let sampleUrls = $state<string[]>([]);
+  let sampleIds = $state<number[]>([]);
 
   onMount(() => {
-    sampleUrls = getSampleGridUrls();
+    sampleIds = getSampleGridIds();
 
     // Fade in side rail
     setTimeout(() => { railVisible = true; }, 200);
@@ -298,9 +297,9 @@
   <!-- Secondary section -->
   <section class="explore-section">
     <div class="sample-grid">
-      {#each sampleUrls as url, i}
+      {#each sampleIds as id, i}
         <div class="sample-tile" style="animation-delay: {i * 30}ms">
-          <img src={url} alt="" loading="lazy" />
+          <UnsigImage {id} dim={128} />
         </div>
       {/each}
     </div>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { browser } from '$app/environment';
-
-  const S3 = 'https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/256';
-
-  function imgUrl(id: number): string {
-    return `${S3}/${id.toString().padStart(5, '0')}.png`;
-  }
+  import UnsigImage from '$lib/components/UnsigImage.svelte';
 
   let visibleSections = $state<Set<string>>(new Set());
 
@@ -137,7 +132,7 @@
         <div id="colors" class="example-grid cols-3 reveal" class:visible={visibleSections.has('colors')}>
           {#each colorExamples as ex, i}
             <figure style="animation-delay: {i * 100}ms">
-              <img src={imgUrl(ex.id)} alt="unsig #{ex.id.toString().padStart(5, '0')}" loading="lazy" />
+              <UnsigImage id={ex.id} dim={256} alt="unsig #{ex.id.toString().padStart(5, '0')}" />
               <figcaption>{ex.label}</figcaption>
             </figure>
           {/each}
@@ -153,7 +148,7 @@
         <div id="distributions" class="example-grid cols-2 reveal" class:visible={visibleSections.has('distributions')}>
           {#each distributionExamples as ex, i}
             <figure style="animation-delay: {i * 100}ms">
-              <img src={imgUrl(ex.id)} alt="unsig #{ex.id.toString().padStart(5, '0')}" loading="lazy" />
+              <UnsigImage id={ex.id} dim={256} alt="unsig #{ex.id.toString().padStart(5, '0')}" />
               <figcaption>{ex.label}</figcaption>
             </figure>
           {/each}
@@ -169,7 +164,7 @@
         <div id="rotations" class="example-grid cols-3 reveal" class:visible={visibleSections.has('rotations')}>
           {#each rotationExamples as ex, i}
             <figure style="animation-delay: {i * 100}ms">
-              <img src={imgUrl(ex.id)} alt="unsig #{ex.id.toString().padStart(5, '0')}" loading="lazy" />
+              <UnsigImage id={ex.id} dim={256} alt="unsig #{ex.id.toString().padStart(5, '0')}" />
               <figcaption>{ex.label}</figcaption>
             </figure>
           {/each}
@@ -186,7 +181,7 @@
         <div id="multipliers" class="example-grid cols-4 reveal" class:visible={visibleSections.has('multipliers')}>
           {#each multiplierExamples as ex, i}
             <figure style="animation-delay: {i * 100}ms">
-              <img src={imgUrl(ex.id)} alt="unsig #{ex.id.toString().padStart(5, '0')}" loading="lazy" />
+              <UnsigImage id={ex.id} dim={256} alt="unsig #{ex.id.toString().padStart(5, '0')}" />
               <figcaption>{ex.label}</figcaption>
             </figure>
           {/each}

--- a/src/routes/arrangements/+page.svelte
+++ b/src/routes/arrangements/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { PageData } from './$types';
+  import UnsigImage from '$lib/components/UnsigImage.svelte';
   
   // Get the data from the server load function
   const { data } = $props<{data: PageData}>();
@@ -139,8 +140,9 @@
                   <div class="grid-cell">
                     {#if cell}
                       <div class="cell-content">
-                        <img
-                          src="https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/256/{cell.unsigIndex.toString().padStart(5, '0')}.png"
+                        <UnsigImage
+                          id={cell.unsigIndex}
+                          dim={256}
                           alt="unsig {cell.unsigIndex}"
                           class="w-full h-full object-cover"
                         />

--- a/src/routes/arrangements/[txid]/+page.svelte
+++ b/src/routes/arrangements/[txid]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Modal from '$lib/components/Modal.svelte';
+  import UnsigImage from '$lib/components/UnsigImage.svelte';
   import { getUnsig } from '$lib/unsigs';
   import { generateUnsigAsync } from '$lib/unsig/worker-api';
   import { createUnsig, unsigToImageData } from '$lib/unsig/generator';
@@ -165,8 +166,9 @@
             <div class="grid-cell">
               {#if cell}
                 <div class="relative group">
-                  <img
-                    src="https://s3.ap-northeast-1.amazonaws.com/unsigs.com/images/256/{cell.unsigIndex.toString().padStart(5, '0')}.png"
+                  <UnsigImage
+                    id={cell.unsigIndex}
+                    dim={256}
                     alt="unsig {cell.unsigIndex}"
                     class="w-full h-full object-cover"
                   />


### PR DESCRIPTION
Add shared singleton worker pool + LRU cache (image-cache.ts) and drop-in UnsigImage.svelte component. Migrate all 8 files that referenced s3.ap-northeast-1.amazonaws.com to generate images client-side via web workers, eliminating the external S3 dependency.

https://claude.ai/code/session_01PxHgrUwnzyzU3PJWCbkEyc